### PR TITLE
Fix: verkeerde datum toekomstige koersen

### DIFF
--- a/geensnorbothook.php
+++ b/geensnorbothook.php
@@ -234,7 +234,7 @@ if ($text == 'week') {
 }
 
 //PI number
-if ($text == 'pi') {
+if ($text == 'pi' || $text == 'π') {
     $content = ['chat_id' => $chat_id, 'text' => pi(), 'parse_mode' => 'Markdown', 'disable_web_page_preview' => true];
     $telegram->sendMessage($content);
 

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -3,7 +3,8 @@
 require_once 'utilities.php';
 
 test('Unix timestamp naar nederlanse datum formatteren', function () {
-    expect(getFormattedDate('1708955470'))->toBe('26 februari');
+    expect(getFormattedDate(DateTime::createFromFormat('Ymd', '20240226')))->toBe('26 februari');
+
 });
 
 test('Interval in dagen in het nederlands voor 1 dag', function () {

--- a/tests/WielrennenTest.php
+++ b/tests/WielrennenTest.php
@@ -24,7 +24,6 @@ test('Er start morgen een koers', function () {
     expect(getKoersenTekst($parsedICS, '20240301'))->toContain('morgen');
 });
 
-
 test('Datum van koersen in de toekomst is correct', function () {
     $parsedICS = json_decode(file_get_contents('tests/fixtures/cyclingCalendar2024.json'));
     expect(getKoersenTekst($parsedICS, '20240314'))->toContain('15 maart start Milano');

--- a/tests/WielrennenTest.php
+++ b/tests/WielrennenTest.php
@@ -26,5 +26,5 @@ test('Er start morgen een koers', function () {
 
 test('Datum van koersen in de toekomst is correct', function () {
     $parsedICS = json_decode(file_get_contents('tests/fixtures/cyclingCalendar2024.json'));
-    expect(getKoersenTekst($parsedICS, '20240314'))->toContain('15 maart start Milano');
+    expect(getKoersenTekst($parsedICS, '20240314'))->toContain('16 maart start Milano');
 });

--- a/tests/WielrennenTest.php
+++ b/tests/WielrennenTest.php
@@ -14,7 +14,6 @@ test('Er wordt geen koers gereden op de gekozen datum.', function () {
 });
 
 test('Er wordt een koers gereden op de gekozen datum.', function () {
-
     $parsedICS = json_decode(file_get_contents('tests/fixtures/cyclingCalendar2024.json'));
     expect(getKoersenTekst($parsedICS, '20240302'))->toStartWith('**Het is koers!**');
 
@@ -23,4 +22,10 @@ test('Er wordt een koers gereden op de gekozen datum.', function () {
 test('Er start morgen een koers', function () {
     $parsedICS = json_decode(file_get_contents('tests/fixtures/cyclingCalendar2024.json'));
     expect(getKoersenTekst($parsedICS, '20240301'))->toContain('morgen');
+});
+
+
+test('Datum van koersen in de toekomst is correct', function () {
+    $parsedICS = json_decode(file_get_contents('tests/fixtures/cyclingCalendar2024.json'));
+    expect(getKoersenTekst($parsedICS, '20240314'))->toContain('15 maart start Milano');
 });

--- a/utilities.php
+++ b/utilities.php
@@ -21,15 +21,12 @@ function getParsedCalendar(string $calendarLocation): array
 
 }
 
-function getFormattedDate(int $date): string
+function getFormattedDate(object $dateObject): string
 {
     $maandNamenEngels = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     $maandNamenNederlands = ['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december'];
 
-    $dateObject = DateTime::createFromFormat('U', $date);
-
     return str_replace($maandNamenEngels, $maandNamenNederlands, $dateObject->format('j F'));
-
 }
 
 function getFormattedIntervalDays(string $startDate, string $endDate): string

--- a/wielrennen.php
+++ b/wielrennen.php
@@ -19,7 +19,7 @@ function getKoersenTekst(array $parsedICS, string $referentieDatum): string
             } elseif ($koers->dtstart <= $referentieDatum && $koers->dtend - 1 >= $referentieDatum) {//Meerdaagse koers, vandaag bezig
 
                 if ($koers->dtstart == $referentieDatum) {//Meerdaagse koers, en de start is vandaag
-                    $koersenTekst .= " \n Vandaag start ".$koers->summary.'. Deze duurt tot en met '.getFormattedDate(strtotime('yesterday', strtotime($koers->dtend)));
+                    $koersenTekst .= " \n Vandaag start ".$koers->summary.'. Deze duurt tot en met '.getFormattedDate((DateTime::createFromFormat('Ymd', $koers->dsend))->modify('-1 day'));
 
                 } elseif ($koers->dtend - 1 == $referentieDatum) {
 
@@ -27,7 +27,7 @@ function getKoersenTekst(array $parsedICS, string $referentieDatum): string
 
                 } else {//Meerdaagse koers en hij is eerder gestart
                     $dagVanKoers = $referentieDatum - $koers->dtstart + 1;
-                    $koersenTekst .= "\n Vandaag is dag ".$dagVanKoers.' van '.$koers->summary.'. Deze duurt tot en met '.getFormattedDate(strtotime('yesterday', strtotime($koers->dtend))).'.';
+                    $koersenTekst .= "\n Vandaag is dag ".$dagVanKoers.' van '.$koers->summary.'. Deze duurt tot en met '.getFormattedDate((DateTime::createFromFormat('Ymd', $koers->dsend))->modify('-1 day')).'.';
                 }
 
             }
@@ -37,12 +37,12 @@ function getKoersenTekst(array $parsedICS, string $referentieDatum): string
                 if ($koers->dtstart == date('Ymd', strtotime('+1 day', strtotime($referentieDatum)))) {
                     $startTekst = 'morgen';
                 } else {
-                    $startTekst = getFormattedDate(strtotime($koers->dtstart));
+                    $startTekst = getFormattedDate(DateTime::createFromFormat('Ymd', $koers->dtstart));
                 }
                 $koersenTekstBinnenkort .= "\n- ".$startTekst.' start '.$koers->summary.'.';
                 if ((strtotime($koers->dtend) - strtotime($koers->dtstart)) > 86400) {
 
-                    $koersenTekstBinnenkort .= ' Deze duurt tot en met '.getFormattedDate(strtotime('yesterday', strtotime($koers->dtend))).'.';
+                    $koersenTekstBinnenkort .= ' Deze duurt tot en met '.getFormattedDate((DateTime::createFromFormat('Ymd', $koers->dtend))->modify('-1 day'));
                 }
             }
         }

--- a/wielrennen.php
+++ b/wielrennen.php
@@ -33,7 +33,7 @@ function getKoersenTekst(array $parsedICS, string $referentieDatum): string
             }
 
             //Binnenkort
-            if (strtotime($koers->dtstart) > strtotime($referentieDatum) && strtotime($koers->dtstart) < strtotime('+2 week', strtotime($referentieDatum))) {
+            if (strtotime($koers->dtstart) > strtotime($referentieDatum) && strtotime($koers->dtstart) < strtotime('+1 week', strtotime($referentieDatum))) {
                 if ($koers->dtstart == date('Ymd', strtotime('+1 day', strtotime($referentieDatum)))) {
                     $startTekst = 'morgen';
                 } else {


### PR DESCRIPTION
En ook nog:
- π voor Pi
- Alleen de koersen van de komende week ipv 2 weken vooruit